### PR TITLE
Will option on SessionManager and change subscriptions while connected

### DIFF
--- a/MQTTClient/MQTTClient/MQTTSessionManager.h
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.h
@@ -85,18 +85,35 @@ typedef NS_ENUM(int, MQTTSessionManagerState) {
              auth:(BOOL)auth
              user:(NSString *)user
              pass:(NSString *)pass
+         willSend:(BOOL)willSend
         willTopic:(NSString *)willTopic
              will:(NSData *)will
           willQos:(MQTTQosLevel)willQos
    willRetainFlag:(BOOL)willRetainFlag
      withClientId:(NSString *)clientId;
 
+     /** Backward compatability for calls without willSend*/
+
+     - (void)connectTo:(NSString *)host
+                  port:(NSInteger)port
+                   tls:(BOOL)tls
+             keepalive:(NSInteger)keepalive
+                 clean:(BOOL)clean
+                  auth:(BOOL)auth
+                  user:(NSString *)user
+                  pass:(NSString *)pass
+             willTopic:(NSString *)willTopic
+                  will:(NSData *)will
+               willQos:(MQTTQosLevel)willQos
+        willRetainFlag:(BOOL)willRetainFlag
+          withClientId:(NSString *)clientId;
+
 /** Re-Connects to the MQTT broker using the parameters for given in the connectTo method
  */
 - (void)connectToLast;
 
 /** publishes data on a given topic at a specified QoS level and retain flag
- 
+
  @param data the data to be sent. length may range from 0 to 268,435,455 - 4 - _lengthof-topic_ bytes. Defaults to length 0.
  @param topic the Topic to identify the data
  @param retainFlag if YES, data is stored on the MQTT broker until overwritten by the next publish with retainFlag = YES

--- a/MQTTClient/MQTTClient/MQTTSessionManager.h
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.h
@@ -85,9 +85,9 @@ typedef NS_ENUM(int, MQTTSessionManagerState) {
              auth:(BOOL)auth
              user:(NSString *)user
              pass:(NSString *)pass
-         willSend:(BOOL)willSend
+             will:(BOOL)will
         willTopic:(NSString *)willTopic
-             will:(NSData *)will
+          willMsg:(NSData *)willMsg
           willQos:(MQTTQosLevel)willQos
    willRetainFlag:(BOOL)willRetainFlag
      withClientId:(NSString *)clientId;

--- a/MQTTClient/MQTTClient/MQTTSessionManager.m
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.m
@@ -24,11 +24,11 @@
 @property (nonatomic) NSInteger keepalive;
 @property (nonatomic) BOOL clean;
 @property (nonatomic) BOOL auth;
-@property (nonatomic) BOOL willSend;
+@property (nonatomic) BOOL will;
 @property (strong, nonatomic) NSString *user;
 @property (strong, nonatomic) NSString *pass;
 @property (strong, nonatomic) NSString *willTopic;
-@property (strong, nonatomic) NSData *will;
+@property (strong, nonatomic) NSData *willMsg;
 @property (nonatomic) NSInteger willQos;
 @property (nonatomic) BOOL willRetainFlag;
 @property (strong, nonatomic) NSString *clientId;
@@ -118,9 +118,9 @@
                auth:auth
                user:user
                pass:pass
-           willSend:YES
+               will:YES
           willTopic:willTopic
-               will:will
+            willMsg:will
             willQos:willQos
      willRetainFlag:willRetainFlag
        withClientId:clientId];
@@ -134,9 +134,9 @@
              auth:(BOOL)auth
              user:(NSString *)user
              pass:(NSString *)pass
-         willSend:(BOOL)willSend
+             will:(BOOL)will
         willTopic:(NSString *)willTopic
-             will:(NSData *)will
+          willMsg:(NSData *)willMsg
           willQos:(MQTTQosLevel)willQos
    willRetainFlag:(BOOL)willRetainFlag
      withClientId:(NSString *)clientId
@@ -163,9 +163,9 @@
         self.auth = auth;
         self.user = user;
         self.pass = pass;
-        self.willTopic = willTopic;
         self.will = will;
-        self.willSend=willSend;
+        self.willTopic = willTopic;
+        self.willMsg=willMsg;
         self.willQos = willQos;
         self.willRetainFlag = willRetainFlag;
         self.clientId = clientId;
@@ -175,9 +175,9 @@
                                                     password:auth ? pass : nil
                                                    keepAlive:keepalive
                                                 cleanSession:clean
-                                                        will:willSend
+                                                        will:will
                                                    willTopic:willTopic
-                                                     willMsg:will
+                                                     willMsg:willMsg
                                                      willQoS:willQos
                                               willRetainFlag:willRetainFlag
                                                protocolLevel:4


### PR DESCRIPTION
This addresses two issues in SessionManager:
-There was no option to not send a will on disconnect. The is fork allows "will" to be sent as boolean YES or NO, and the data is sent as willMsg argument, matching the MQTTSession arguments. The old connectTo call is preserved for compatibility.
-subscriptions can now be changed while the session is connected