### PR TITLE
Added auto-reconnecting for MQTTSessionManager after setting changes

### DIFF
--- a/MQTTClient/MQTTClient/MQTTSessionManager.m
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.m
@@ -197,6 +197,7 @@
    securityPolicy:(MQTTSSLSecurityPolicy *)securityPolicy
      certificates:(NSArray *)certificates
 {
+    BOOL shouldReconnect = self.session != nil;
     if (!self.session ||
         ![host isEqualToString:self.host] ||
         port != self.port ||
@@ -255,7 +256,14 @@
         self.reconnectTime = RECONNECT_TIMER;
         self.reconnectFlag = FALSE;
     }
-    [self connectToInternal];
+    if(shouldReconnect){
+        NSLog(@"MQTTSessionManager reconnecting");
+        [self disconnect];
+        [self reconnect];
+    }else{
+        NSLog(@"MQTTSessionManager connecting");
+        [self connectToInternal];
+    }
 }
 
 - (UInt16)sendData:(NSData *)data topic:(NSString *)topic qos:(MQTTQosLevel)qos retain:(BOOL)retainFlag


### PR DESCRIPTION
There's currently no way of changing username/password options with API exposed by MQTTSessionManager.

Perhaps better solution is to change `MQTTSession.userName` and `MQTTSession.password` instead of reconnecting, but this solution is good enough. Because this behavior is the same as Eclipse Paho Android Service/ MQTTAsyncClient, which doesn't allow changing of username/password without reconnecting, either, and I want my iOS client behaves exactly like my Android version.