### PR TITLE
Fix inconsistent connect params causes invalid CONNECT message

### DIFF
--- a/MQTTClient/MQTTClient/MQTTMessage.m
+++ b/MQTTClient/MQTTClient/MQTTMessage.m
@@ -89,10 +89,10 @@
     [data appendByte:flags];
     [data appendUInt16BigEndian:keepAlive];
     [data appendMQTTString:clientId];
-    if (willTopic) {
+    if (will && willTopic) {
         [data appendMQTTString:willTopic];
     }
-    if (willMsg) {
+    if (will && willMsg) {
         [data appendUInt16BigEndian:[willMsg length]];
         [data appendData:willMsg];
     }


### PR DESCRIPTION
A session initialized without a will but with a non-nil willTopic ends up sending the wrong CONNECT message. The will topic and the will message would be interpreted by the server as something else like the username and the password. The fix just skips the will parts of the connect message if the will flag is not set as the specs says.

To replicate use a server without anonymous connections and try to connect using sending false as will and any non-empty string as willTopic. I had the problem and tested this trivial fix using vernemq.

This should not work as the will topic is confused as the username:
```objc
[_mqttSessionManager connectTo:@"localhost" port:1883 tls:NO keepalive:1 clean:NO auth:YES user:@"user" pass:@"pass" will:NO willTopic:@"anythinghere" willMsg:nil willQos:MQTTQosLevelAtLeastOnce willRetainFlag:YES withClientId:clientId securityPolicy:nil certificates:nil];
```