### PR TITLE
Wrong preprocessor macro TARGET_OS_MAC

### DIFF
--- a/MQTTClient/MQTTClient/MQTTSessionManager.h
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#ifndef TARGET_OS_MAC
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 #import <UIKit/UIKit.h>
 #endif
 #import "MQTTSession.h"

--- a/MQTTClient/MQTTClient/MQTTSessionManager.m
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.m
@@ -37,7 +37,7 @@
 
 @property (strong, nonatomic) NSTimer *disconnectTimer;
 @property (strong, nonatomic) NSTimer *activityTimer;
-#ifndef TARGET_OS_MAC
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 @property (nonatomic) UIBackgroundTaskIdentifier backgroundTask;
 #endif
 
@@ -60,7 +60,7 @@
     self = [super init];
 
     self.state = MQTTSessionManagerStateStarting;
-#ifndef TARGET_OS_MAC
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     self.backgroundTask = UIBackgroundTaskInvalid;
 
     NSNotificationCenter *defaultCenter = [NSNotificationCenter defaultCenter];
@@ -95,7 +95,7 @@
     return self;
 }
 
-#ifndef TARGET_OS_MAC
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 - (void)appWillResignActive
 {
     [self disconnect];
@@ -315,7 +315,7 @@
         case MQTTSessionEventConnectionClosed:
         case MQTTSessionEventConnectionClosedByBroker:
             self.state = MQTTSessionManagerStateClosed;
-#ifndef TARGET_OS_MAC
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
             if (self.backgroundTask) {
                 [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTask];
                 self.backgroundTask = UIBackgroundTaskInvalid;


### PR DESCRIPTION
I was noticing that ``appWillResignActive``was never called so I asked myself why.

[Based on this comment on another repo](https://github.com/indragiek/SNRMusicKit/issues/5#issue-6475150), I guess we need to change those pre-processor macros.

``TARGET_OS_IPHONE`` is a variant of ``TARGET_OS_MAC`` so the code won't even run on iOS.
Correct me if I'm wrong.
