### PR TITLE
Fixed session manager being in wrong state if appDidBecomeActive is c…

### DIFF
--- a/MQTTClient/MQTTClient/MQTTSessionManager.m
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.m
@@ -371,7 +371,8 @@
 
 - (void)connectToInternal
 {
-    if (self.state == MQTTSessionManagerStateStarting) {
+    if (self.state == MQTTSessionManagerStateStarting
+        && self.session != nil) {
         self.state = MQTTSessionManagerStateConnecting;
         [self.session connectToHost:self.host
                                port:self.port


### PR DESCRIPTION
…alled before connect being called;

Explanation: 

If apps instantiated `MQTTSessionManager` and don't call connect immediately, there will be cases that `MQTTSessionManager.appDidBecomeActive` will be called before apps call `MQTTSessionManager.connectTo` methods. In those cases, `MQTTSessionManager`'s internal `state` property will be wrongly set to `MQTTSessionManagerStateConnecting`, thus, when apps call `MQTTSessionManager.connectTo`, `MQTTSessionManager` will refuse to connect.

This patched just added one line to double check if session object is properly initiated to prevent above scenarios from happening.