### PR TITLE
Set the default value for SessionManager

### DIFF
--- a/MQTTClient/MQTTClient/MQTTPersistence.h
+++ b/MQTTClient/MQTTClient/MQTTPersistence.h
@@ -10,6 +10,11 @@
 #import <CoreData/CoreData.h>
 #import "MQTTMessage.h"
 
+static BOOL const MQTT_PERSISTENT = NO;
+static NSInteger const MQTT_MAX_SIZE = 64 * 1024 * 1024;
+static NSInteger const MQTT_MAX_WINDOW_SIZE = 16;
+static NSInteger const MQTT_MAX_MESSAGES = 1024;
+
 @interface MQTTFlow : NSManagedObject
 @property (strong, nonatomic) NSString *clientId;
 @property (strong, nonatomic) NSNumber *incomingFlag;

--- a/MQTTClient/MQTTClient/MQTTPersistence.m
+++ b/MQTTClient/MQTTClient/MQTTPersistence.m
@@ -27,12 +27,6 @@
 #define DEBUGPERSIST FALSE
 #endif
 
-#define PERSISTENT NO
-#define MAX_SIZE 64*1024*1024
-#define MAX_WINDOW_SIZE 16
-#define MAX_MESSAGES 1024
-
-
 @interface MQTTPersistence()
 //@property (strong, nonatomic) NSManagedObjectContext *managedObjectContext;
 @end
@@ -48,10 +42,10 @@ static unsigned long long fileSystemFreeSize;
 
 - (MQTTPersistence *)init {
     self = [super init];
-    self.persistent = PERSISTENT;
-    self.maxSize = MAX_SIZE;
-    self.maxMessages = MAX_MESSAGES;
-    self.maxWindowSize = MAX_WINDOW_SIZE;
+    self.persistent = MQTT_PERSISTENT;
+    self.maxSize = MQTT_MAX_SIZE;
+    self.maxMessages = MQTT_MAX_MESSAGES;
+    self.maxWindowSize = MQTT_MAX_WINDOW_SIZE;
     if (!lock) {
         lock = [[NSRecursiveLock alloc] init];
     }

--- a/MQTTClient/MQTTClient/MQTTSessionManager.m
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.m
@@ -63,6 +63,12 @@
     self.state = MQTTSessionManagerStateStarting;
     self.internalSubscriptions = [[NSMutableDictionary alloc] init];
     self.effectiveSubscriptions = [[NSMutableDictionary alloc] init];
+    
+    //Use the default value 
+    self.persistent = MQTT_PERSISTENT;
+    self.maxSize = MQTT_MAX_SIZE;
+    self.maxMessages = MQTT_MAX_MESSAGES;
+    self.maxWindowSize = MQTT_MAX_WINDOW_SIZE;
 
 #if TARGET_OS_IPHONE == 1
     self.backgroundTask = UIBackgroundTaskInvalid;


### PR DESCRIPTION
When I create an SessionManager with the default init method, the MAX_SIZE, MAX_MESSAGES and MAX_WINDOW are all set to 0, which will drop offline messages when receiving multiple messages at the same time.  This pr just simple set them to the default value.