### PR TITLE
Reconnect on ConnectionClosedByBroker

### DIFF
--- a/MQTTClient/MQTTClient/MQTTSessionManager.m
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.m
@@ -329,8 +329,7 @@
             break;
         }
         case MQTTSessionEventConnectionClosed:
-        case MQTTSessionEventConnectionClosedByBroker:
-            self.state = MQTTSessionManagerStateClosed;
+        {
 #if TARGET_OS_IPHONE == 1
             if (self.backgroundTask) {
                 [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTask];
@@ -339,9 +338,11 @@
 #endif
             self.state = MQTTSessionManagerStateStarting;
             break;
+        }
         case MQTTSessionEventProtocolError:
         case MQTTSessionEventConnectionRefused:
         case MQTTSessionEventConnectionError:
+        case MQTTSessionEventConnectionClosedByBroker:
         {
             self.reconnectTimer = [NSTimer timerWithTimeInterval:self.reconnectTime
                                                           target:self


### PR DESCRIPTION
Fixes #108 
- with this change, this event is treated the same as ProtocolError, ConnectionRefused, and ConnectionError. The SessionManager status is set to 'Error' and the reconnect loop starts.
- removed an extraneous call to set self.state