### PR TITLE
transport closed is not an error if disconnecting

### DIFF
--- a/MQTTClient/MQTTClient/MQTTSession.m
+++ b/MQTTClient/MQTTClient/MQTTSession.m
@@ -1129,8 +1129,11 @@
 - (void)mqttTransportDidClose:(id<MQTTTransport>)mqttTransport {
     DDLogVerbose(@"[MQTTSession] mqttTransport mqttTransportDidClose");
     
-    [self error:MQTTSessionEventConnectionClosedByBroker error:nil];
-    
+    if (_status == MQTTSessionStatusDisconnecting) {
+        [self closeInternal];
+    } else {
+        [self error:MQTTSessionEventConnectionClosedByBroker error:nil];
+    }
 }
 
 - (void)mqttTransportDidOpen:(id<MQTTTransport>)mqttTransport {


### PR DESCRIPTION
In my previous pull request, I overlooked that connectionClosedByBroker was being fired when the client disconnects normally. This, with my change, was causing the client to reconnect upon disconnecting (while transitioning to the background). Upon further inspection, I learned that when the MQTTSession is connected, and disconnect is called, the session waits for the server to close the connection before calling closeInternal(). Therefore, the method in this commit is being called both when the connection is closed by the broker and when the client sends disconnect.

Since we expect the broker to close the connection when the send disconnect, it seems inappropriate to treat it as an error. Here is the relevant part of the MQTT spec: (from http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc385349355)

> On receipt of DISCONNECT the Server:
> - MUST discard any Will Message associated with the current connection without publishing it, as described in Section 3.1.2.5 [MQTT-3.14.4-3].
> - SHOULD close the Network Connection if the Client has not already done so.

If it's okay for the client to close the connection rather than the server, then an alternative to merging this PR would be to call closeInternal() right after sending the disconnect message here:
https://github.com/ckrey/MQTT-Client-Framework/blob/master/MQTTClient/MQTTClient/MQTTSession.m#L313
Then, it seems to me that the below method would never be called on a normal disconnect because the client stops the decoder and closes the stream before it closes from the server's end.

I haven't tested that, but I have tested this PR. Please take a look and let me know what you think.
