### PR TITLE
fixed crash when the subscriptions dictionary changed while the client is connecting

### DIFF
--- a/MQTTClient/MQTTClient/MQTTSessionManager.m
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.m
@@ -383,12 +383,13 @@
 
 - (void)connected:(MQTTSession *)session sessionPresent:(BOOL)sessionPresent {
     if (self.clean || !self.reconnectFlag || !sessionPresent) {
-        if (self.subscriptions && [self.subscriptions count]) {
+        NSDictionary *subscriptions = [self.subscriptions copy];
+        if (subscriptions.count) {
             [self.effectiveSubscriptions removeAllObjects];
             self.effectiveSubscriptions = self.effectiveSubscriptions;
-            [self.session subscribeToTopics:self.subscriptions subscribeHandler:^(NSError *error, NSArray<NSNumber *> *gQoss) {
+            [self.session subscribeToTopics:subscriptions subscribeHandler:^(NSError *error, NSArray<NSNumber *> *gQoss) {
                 if (!error) {
-                    NSArray<NSString *> *allTopics = self.subscriptions.allKeys;
+                    NSArray<NSString *> *allTopics = subscriptions.allKeys;
                     for (int i = 0; i < allTopics.count; i++) {
                         NSString *topic = allTopics[i];
                         NSNumber *gQos = gQoss[i];


### PR DESCRIPTION
fixed crash when the subscriptions dictionary changed while the client is connecting

*** -[__NSArrayM objectAtIndex:]: index 1 beyond bounds [0 .. 0]

Use case is simple:
1. the mqtt client is disconnected
2. subscribe to some topic "AA"
3. the mqtt client starts connection
4. the mqtt client has finished connection and is subscribing to the topic "AA"
5. subscribe to another topic "BB"
6. the mqtt client has subscribed to the topic "AA" and is trying to update effectiveSubscriptions
7. crashed at NSNumber *gQos = gQoss[i]; cause we do not have the qos for the topic "BB" that we are not subscribed yet