### PR TITLE
Fix issue #113

### DIFF
--- a/MQTTClient/MQTTClient/MQTTSessionManager.m
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.m
@@ -449,7 +449,7 @@
 - (void)setSubscriptions:(NSDictionary<NSString *, NSNumber *> *)newSubscriptions
 {
     if (self.state==MQTTSessionManagerStateConnected) {
-        for (NSString *topicFilter in self.effectiveSubscriptions) {
+        for (NSString *topicFilter in self.effectiveSubscriptions.allKeys) {
             if (![newSubscriptions objectForKey:topicFilter]) {
                 [self.session unsubscribeTopic:topicFilter unsubscribeHandler:^(NSError *error) {
                     if (!error) {


### PR DESCRIPTION
effectiveSubscriptions was mutated while being enumerated.
To fix this we enumerate over an array of all the keys instead of enumerating over the dictionary.

I'm not sure this fixes the EXC_BAD_ACCESS as well but I couldn't reproduce it.