### PR TITLE
Adding method for MQTTSessionManager to include protocolLevel variable

### DIFF
--- a/MQTTClient/MQTTClient/MQTTSessionManager.h
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.h
@@ -115,6 +115,43 @@ typedef NS_ENUM(int, MQTTSessionManagerState) {
                                 maxMessages:(NSUInteger)maxMessages
                                     maxSize:(NSUInteger)maxSize;
 
+/** Connects to the MQTT broker and stores the parameters for subsequent reconnects
+ * @param host specifies the hostname or ip address to connect to. Defaults to @"localhost".
+ * @param port specifies the port to connect to
+ * @param tls specifies whether to use SSL or not
+ * @param keepalive The Keep Alive is a time interval measured in seconds. The MQTTClient ensures that the interval between Control Packets being sent does not exceed the Keep Alive value. In the  absence of sending any other Control Packets, the Client sends a PINGREQ Packet.
+ * @param clean specifies if the server should discard previous session information.
+ * @param auth specifies the user and pass parameters should be used for authenthication
+ * @param user an NSString object containing the user's name (or ID) for authentication. May be nil.
+ * @param pass an NSString object containing the user's password. If userName is nil, password must be nil as well.
+ * @param will indicates whether a will shall be sent
+ * @param willTopic the Will Topic is a string, may be nil
+ * @param willMsg the Will Message, might be zero length or nil
+ * @param willQos specifies the QoS level to be used when publishing the Will Message.
+ * @param willRetainFlag indicates if the server should publish the Will Messages with retainFlag.
+ * @param clientId The Client Identifier identifies the Client to the Server. If nil, a random clientId is generated.
+ * @param securityPolicy A custom SSL security policy or nil.
+ * @param certificates An NSArray of the pinned certificates to use or nil.
+ * @param Protocol version of the connection.
+ */
+
+- (void)connectTo:(NSString *)host
+             port:(NSInteger)port
+              tls:(BOOL)tls
+        keepalive:(NSInteger)keepalive
+            clean:(BOOL)clean
+             auth:(BOOL)auth
+             user:(NSString *)user
+             pass:(NSString *)pass
+             will:(BOOL)will
+        willTopic:(NSString *)willTopic
+          willMsg:(NSData *)willMsg
+          willQos:(MQTTQosLevel)willQos
+   willRetainFlag:(BOOL)willRetainFlag
+     withClientId:(NSString *)clientId
+   securityPolicy:(MQTTSSLSecurityPolicy *)securityPolicy
+     certificates:(NSArray *)certificates
+    protocolLevel:(MQTTProtocolVersion)protocolLevel;
 
 
 /** Connects to the MQTT broker and stores the parameters for subsequent reconnects


### PR DESCRIPTION
I needed this method to connect to a V3.1 mosquitto broker. The default still uses V3.1.1 so this change is backwards compatible