### PR TITLE
Call connect handler when connection is closed by broker without sending a CONNACK

### DIFF
--- a/MQTTClient/MQTTClient/MQTTSession.h
+++ b/MQTTClient/MQTTClient/MQTTSession.h
@@ -52,6 +52,30 @@ typedef NS_ENUM(NSInteger, MQTTSessionEvent) {
     MQTTSessionEventConnectionClosedByBroker
 };
 
+/**
+ The error domain used for all errors created by MQTTSession
+ */
+extern NSString * const MQTTSessionErrorDomain;
+
+/**
+ The error codes used for all errors created by MQTTSession
+ */
+typedef NS_ENUM(NSInteger, MQTTSessionError) {
+    MQTTSessionErrorConnectionRefused = -8, // Sent if the server closes the connection without sending an appropriate error CONNACK
+    MQTTSessionErrorIllegalMessageReceived = -7,
+    MQTTSessionErrorDroppingOutgoingMessage = -6, // For some reason the value is the same as for MQTTSessionErrorNoResponse
+    MQTTSessionErrorNoResponse = -6, // For some reason the value is the same as for MQTTSessionErrorDroppingOutgoingMessage
+    MQTTSessionErrorEncoderNotReady = -5,
+    MQTTSessionErrorInvalidConnackReceived = -2, // Sent if the message received from server was an invalid connack message
+    MQTTSessionErrorNoConnackReceived = -1, // Sent if first message received from server was no connack message
+    MQTTSessionErrorConnackUnacceptableProtocolVersion = 1, // Value as defined by MQTT Protocol
+    MQTTSessionErrorConnackIdentifierRejected = 2, // Value as defined by MQTT Protocol
+    MQTTSessionErrorConnackServeUnavailable = 3, // Value as defined by MQTT Protocol
+    MQTTSessionErrorConnackBadUsernameOrPassword = 4, // Value as defined by MQTT Protocol
+    MQTTSessionErrorConnackNotAuthorized = 5, // Value as defined by MQTT Protocol
+    MQTTSessionErrorConnackReserved = 6, // Should be value 6-255, as defined by MQTT Protocol
+};
+
 /** Session delegate gives your application control over the MQTTSession
  @note all callback methods are optional
  */

--- a/MQTTClient/MQTTClient/MQTTSession.m
+++ b/MQTTClient/MQTTClient/MQTTSession.m
@@ -941,6 +941,16 @@ NSString * const MQTTSessionErrorDomain = @"MQTT";
     if(self.connectionHandler){
         self.connectionHandler(eventCode);
     }
+
+    if(eventCode == MQTTSessionEventConnectionClosedByBroker && self.connectHandler) {
+        error = [NSError errorWithDomain:MQTTSessionErrorDomain
+                                    code:MQTTSessionErrorConnectionRefused
+                                userInfo:@{NSLocalizedDescriptionKey : @"Server has closed connection without connack."}];
+
+        MQTTConnectHandler connectHandler = self.connectHandler;
+        self.connectHandler = nil;
+        [self onConnect:connectHandler error:error];
+    }
     
     self.synchronPub = FALSE;
     self.synchronPubMid = 0;


### PR DESCRIPTION
Der MQTT Broker kann eine Verbindung trennen, ohne dem Client vorher ein CONNACK Nachricht zu schicken. Das kann er zB. machen, wenn ein falscher Nutzer oder eine falsche Client ID gesetzt ist (vergleiche 3.1.4 Response in [MQTT v3.1.1](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.pdf) (Zeile 626-629)).

In diesem Fall hat der MQTT Client den Completion Handler von ```- (void)connectWithHandler:``` nicht aufgerufen. Das führt dann beim Verbinden dazu, dass der Activity Indicator ewig angezeigt wird. Dieses Problem löst dieser PR.

Zusätzlich habe ich überall da, wo ```MQTTSession``` ```NSError``` Objekte erzeugt, dafür gesorgt, dass ```MQTTSession``` eine definierte Konstante für die Domain (```MQTTSessionErrorDomain```) und ein Enum für die Error Codes (```MQTTSessionError```) benutzt. Die Werte der Error Codes sind so gestaltet, dass das ganze abwärtskompatibel zu älteren Versionen des MQTT Clients bleibt (nur dann können wir einen PR im originalen Repo stellen).

Würde jetzt sagen, dass wenn wir das im internen review für OK befinden, wir einen PR beim originalen Repo stellen.