### PR TITLE
Fix unread and unused variables

### DIFF
--- a/MQTTClient/MQTTClient/MQTTSession.m
+++ b/MQTTClient/MQTTClient/MQTTSession.m
@@ -696,7 +696,6 @@ NSString * const MQTTSessionErrorDomain = @"MQTT";
     NSRange range = NSMakeRange(2 + topicLength, [data length] - topicLength - 2);
     data = [data subdataWithRange:range];
     if ([msg qos] == 0) {
-        BOOL processed = true;
         if ([self.delegate respondsToSelector:@selector(newMessage:data:onTopic:qos:retained:mid:)]) {
             [self.delegate newMessage:self
                                  data:data
@@ -706,12 +705,12 @@ NSString * const MQTTSessionErrorDomain = @"MQTT";
                                   mid:0];
         }
         if ([self.delegate respondsToSelector:@selector(newMessageWithFeedback:data:onTopic:qos:retained:mid:)]) {
-            processed = [self.delegate newMessageWithFeedback:self
-                                                         data:data
-                                                      onTopic:topic
-                                                          qos:msg.qos
-                                                     retained:msg.retainFlag
-                                                          mid:0];
+            [self.delegate newMessageWithFeedback:self
+                                             data:data
+                                          onTopic:topic
+                                              qos:msg.qos
+                                         retained:msg.retainFlag
+                                              mid:0];
         }
         if (self.messageHandler) {
             self.messageHandler(data, topic);

--- a/MQTTClient/MQTTClient/MQTTSession.m
+++ b/MQTTClient/MQTTClient/MQTTSession.m
@@ -464,7 +464,7 @@ NSString * const MQTTSessionErrorDomain = @"MQTT";
 }
 
 - (void)decoder:(MQTTDecoder*)sender handleEvent:(MQTTDecoderEvent)eventCode error:(NSError *)error {
-    NSArray *events = @[
+    __unused NSArray *events = @[
                         @"MQTTDecoderEventProtocolError",
                         @"MQTTDecoderEventConnectionClosed",
                         @"MQTTDecoderEventConnectionError"

--- a/MQTTClient/MQTTClient/MQTTSessionManager.m
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.m
@@ -362,7 +362,7 @@
 - (void)handleEvent:(MQTTSession *)session event:(MQTTSessionEvent)eventCode error:(NSError *)error
 {
 #ifdef DEBUG
-    const NSDictionary *events = @{
+    __unused const NSDictionary *events = @{
                                    @(MQTTSessionEventConnected): @"connected",
                                    @(MQTTSessionEventConnectionRefused): @"connection refused",
                                    @(MQTTSessionEventConnectionClosed): @"connection closed",


### PR DESCRIPTION
When disabling logs two variables where unused throwing a warning. The static analyzer also flagged another variable as unread. 