### PR TITLE
Adding MQTTSessionManager.h to the umbrella header

### DIFF
--- a/MQTTClient/MQTTFramework/MQTTFramework.h
+++ b/MQTTClient/MQTTFramework/MQTTFramework.h
@@ -17,7 +17,7 @@
 #import "MQTTCFSocketTransport.h"
 #import "MQTTCoreDataPersistence.h"
 #import "MQTTSSLSecurityPolicyTransport.h"
-
+#import "MQTTSessionManager.h"
 
 //! Project version number for MQTTFramework.
 FOUNDATION_EXPORT double MQTTFrameworkVersionNumber;


### PR DESCRIPTION
When using MQTTSessionManager and importing `#import <MQTTFramework/MQTTSessionManager.h>`, XCode will give a warning that the session manager header is not in the umbrella. 
