### PR TITLE
Connection Retry after Closed-by-Broker Errors

### DIFF
--- a/MQTTClient/MQTTClient/MQTTSessionManager.h
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.h
@@ -116,6 +116,9 @@ typedef NS_ENUM(int, MQTTSessionManagerState) {
  * @param maxWindowSize (a positive number, default is 16) to control the number of messages sent before waiting for acknowledgement in Qos 1 or 2. Additional messages are stored and transmitted later.
  * @param maxSize (a positive number of bytes, default is 64 MB) to limit the size of the persistence file. Messages published after the limit is reached are dropped.
  * @param maxMessages (a positive number, default is 1024) to limit the number of messages stored. Additional messages published are dropped.
+ * @param maxRetryInterval The duration at which the connection-retry timer should be capped. When MQTTSessionManager receives a ClosedByBroker or an Error
+    event, it will attempt to reconnect to the broker. The time in between connection attempts is doubled each time, until it remains at maxRetryInterval.
+    Defaults to 64 seconds.
  * @param connectInForeground Whether or not to connect the MQTTSession when the app enters the foreground, and disconnect when it becomes inactive. When NO, the caller is responsible for calling -connectTo: and -disconnect. Defaults to YES.
  * @return the initialized MQTTSessionManager object
  */
@@ -124,6 +127,7 @@ typedef NS_ENUM(int, MQTTSessionManagerState) {
                               maxWindowSize:(NSUInteger)maxWindowSize
                                 maxMessages:(NSUInteger)maxMessages
                                     maxSize:(NSUInteger)maxSize
+                 maxConnectionRetryInterval:(NSTimeInterval)maxRetryInterval
                         connectInForeground:(BOOL)connectInForeground;
 
 /** initWithPersistence sets the MQTTPersistence properties other than default

--- a/MQTTClient/MQTTClient/MQTTSessionManager.m
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.m
@@ -428,6 +428,7 @@
             [self updateState:MQTTSessionManagerStateClosed];
             [self endBackgroundTask];
             [self updateState:MQTTSessionManagerStateStarting];
+            [self triggerDelayedReconnect];
             break;
 
         case MQTTSessionEventProtocolError:


### PR DESCRIPTION
See individual commits. I did some refactoring to simplify `-[MQTTSessionManager handleEvent:event:error:]`, introduced behavior to start the retry sequence for `MQTTSessionEventConnectionClosedByBroker` events, and added a configurable maxRetryTime. 

For our use case, 64 seconds is too long for the user to wait for reestablishing the MQTT connection, and we're comfortable with the broker-side load of going lower than that.