### PR TITLE
Reset PUBLISH/PUBREL command's deadline interval when connection closed

### DIFF
--- a/MQTTClient/MQTTClient/MQTTSession.m
+++ b/MQTTClient/MQTTClient/MQTTSession.m
@@ -372,6 +372,18 @@ NSString * const MQTTSessionErrorDomain = @"MQTT";
         self.decoder.delegate = nil;
     }
     
+    NSArray *flows = [self.persistence allFlowsforClientId:self.clientId
+                                              incomingFlag:NO];
+    for (id<MQTTFlow> flow in flows) {
+        switch ([flow.commandType intValue]) {
+            case MQTTPublish:
+            case MQTTPubrel:
+                flow.deadline = [flow.deadline dateByAddingTimeInterval:-DUPTIMEOUT];
+                [self.persistence sync];
+                break;
+        }
+    }
+    
     self.status = MQTTSessionStatusClosed;
     if ([self.delegate respondsToSelector:@selector(handleEvent:event:error:)]) {
         [self.delegate handleEvent:self event:MQTTSessionEventConnectionClosed error:nil];


### PR DESCRIPTION
When connection got closed after publishing message but before receiving PUBREC,  stored messsage's deadline interval are set as DUPTIMEOUT (such as 20 sec).
This causes other messages that have never published overtakes the message after reconnection.

I've fixed this problem by resetting the message's deadline interval if connection got closed.