### PR TITLE
Revert background reconnect

### DIFF
--- a/MQTTClient/MQTTClient/MQTTSessionManager.m
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.m
@@ -433,7 +433,6 @@
             [self updateState:MQTTSessionManagerStateClosed];
             [self endBackgroundTask];
             [self updateState:MQTTSessionManagerStateStarting];
-            [self triggerDelayedReconnect];
             break;
 
         case MQTTSessionEventProtocolError:


### PR DESCRIPTION
This reverts commit c59945b9fff8832792e82ec913ab29254d276ede.

The original commit, intended to cause the client to reconnect in more error scenarios, was a little too aggressive. It turns out that all clean disconnects would trigger a reconnect sequence, so I am reverting that commit to prevent the client from connecting after the app cleanly disconnects in the background.