### PR TITLE
Expose MQTTSession publicly

### DIFF
--- a/MQTTClient/MQTTClient/MQTTSessionManager.h
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.h
@@ -78,6 +78,10 @@ typedef NS_ENUM(int, MQTTSessionManagerState) {
  */
 @interface MQTTSessionManager : NSObject <MQTTSessionDelegate>
 
+/** Underlying MQTTSession currently in use.
+ */
+@property (strong, nonatomic, readonly) MQTTSession *session;
+
 /** host an NSString containing the hostName or IP address of the Server
  */
 @property (readonly) NSString *host;


### PR DESCRIPTION
This is in a way related to https://github.com/ckrey/MQTT-Client-Framework/pull/337.

It is nice to use `MQTTSessionManager` as it has built in retry mechanism but once instantiated and called `connect`, it is not possible to change anything on it. 
In our specific use case we need to change 2 things:

- password - if connection errors with `MQTTSessionErrorConnackBadUsernameOrPassword` we obtain new password and just update session. Else is handled automatically by manager
- will message - we have some specific requirements where we need to change will message when reconnected

I am not sure if we want to remove `port` and `host` properties since they are now available on session?