### PR TITLE
MQTTSessionManager background task handling

### DIFF
--- a/MQTTClient/MQTTClient/MQTTSession.m
+++ b/MQTTClient/MQTTClient/MQTTSession.m
@@ -531,11 +531,14 @@ NSString * const MQTTSessionErrorDomain = @"MQTT";
     DDLogVerbose(@"[MQTTSession] sending DISCONNECT");
     self.status = MQTTSessionStatusDisconnecting;
 
-    (void)[self encode:[MQTTMessage disconnectMessage:self.protocolLevel
-                                           returnCode:returnCode
-                                sessionExpiryInterval:sessionExpiryInterval
-                                         reasonString:reasonString
-                                         userProperty:userProperty]];
+    BOOL isSent = [self encode:[MQTTMessage disconnectMessage:self.protocolLevel
+                                                   returnCode:returnCode
+                                        sessionExpiryInterval:sessionExpiryInterval
+                                                 reasonString:reasonString
+                                                 userProperty:userProperty]];
+    if (isSent) {
+        [self closeInternal];
+    }
 }
 
 - (void)closeInternal

--- a/MQTTClient/MQTTClient/MQTTSessionManager.m
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.m
@@ -170,10 +170,7 @@
         __weak MQTTSessionManager *weakSelf = self;
         self.backgroundTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
             __strong MQTTSessionManager *strongSelf = weakSelf;
-            if (strongSelf.backgroundTask) {
-                [[UIApplication sharedApplication] endBackgroundTask:strongSelf.backgroundTask];
-                strongSelf.backgroundTask = UIBackgroundTaskInvalid;
-            }
+            [strongSelf endBackgroundTask];
         }];
     }
 }

--- a/MQTTClient/MQTTClient/MQTTSessionManager.m
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.m
@@ -167,6 +167,11 @@
 
 - (void)appDidEnterBackground {
     if (self.shouldConnectInForeground) {
+        if (self.state == MQTTSessionManagerStateClosed || self.state == MQTTSessionManagerStateStarting) {
+            // we don't want to tear down session as it's already closed
+            return;
+        }
+
         __weak MQTTSessionManager *weakSelf = self;
         self.backgroundTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
             __strong MQTTSessionManager *strongSelf = weakSelf;


### PR DESCRIPTION
Hello!
Main issue this PR is fixing is:
I was profiling my app's energy consumption and noticed that after pressing home button app state was changed to background, not suspended(as expected). And the only place where BG task was created is MQTTSessionManager.
I'm using default init, so shouldConnectInForeground is TRUE.

Changes:
1. MQTTSession.m, -(void)disconnectWithReturnCode... :
Motivation: Even after sending MQTTDisconnect message to the broker successfully, NSStreamEventEndEncountered was considered by decoder as an error and session's state was changed to MQTTSessionEventConnectionClosedByBroker. After that MQTTSessionManager was trying to reconnect. I assume that after receiving disconnect message broker will close connection, so this is save.

2. MQTTSessionManager.m, - (void)appDidEnterBackground :
Motivation: If we're not connected we don't want to wait for disconnect.
Am i right assuming MQTTSessionManagerStateStarting signals that there is no communication with the broker?
