### PR TITLE
MQTTSessionManager background task handling

### DIFF
--- a/MQTTClient/MQTTClient/ForegroundReconnection.m
+++ b/MQTTClient/MQTTClient/ForegroundReconnection.m
@@ -55,13 +55,10 @@
 }
 
 - (void)appDidEnterBackground {
-    __weak ForegroundReconnection *weakSelf = self;
+    __weak typeof(self) weakSelf = self;
     self.backgroundTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
-        __strong ForegroundReconnection *strongSelf = weakSelf;
-        if (strongSelf.backgroundTask) {
-            [[UIApplication sharedApplication] endBackgroundTask:strongSelf.backgroundTask];
-            strongSelf.backgroundTask = UIBackgroundTaskInvalid;
-        }
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        [strongSelf endBackgroundTask];
     }];
 }
 

--- a/MQTTClient/MQTTClient/ForegroundReconnection.m
+++ b/MQTTClient/MQTTClient/ForegroundReconnection.m
@@ -55,6 +55,11 @@
 }
 
 - (void)appDidEnterBackground {
+    if (!self.sessionManager.requiresTearDown) {
+        // we don't want to tear down session as it's already closed
+        return;
+    }
+    
     __weak typeof(self) weakSelf = self;
     self.backgroundTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
         __strong typeof(weakSelf) strongSelf = weakSelf;

--- a/MQTTClient/MQTTClient/MQTTSession.m
+++ b/MQTTClient/MQTTClient/MQTTSession.m
@@ -531,11 +531,14 @@ NSString * const MQTTSessionErrorDomain = @"MQTT";
     DDLogVerbose(@"[MQTTSession] sending DISCONNECT");
     self.status = MQTTSessionStatusDisconnecting;
 
-    (void)[self encode:[MQTTMessage disconnectMessage:self.protocolLevel
-                                           returnCode:returnCode
-                                sessionExpiryInterval:sessionExpiryInterval
-                                         reasonString:reasonString
-                                         userProperty:userProperty]];
+    BOOL isSent = [self encode:[MQTTMessage disconnectMessage:self.protocolLevel
+                                                   returnCode:returnCode
+                                        sessionExpiryInterval:sessionExpiryInterval
+                                                 reasonString:reasonString
+                                                 userProperty:userProperty]];
+    if (isSent) {
+        [self closeInternal];
+    }
 }
 
 - (void)closeInternal

--- a/MQTTClient/MQTTClient/MQTTSessionManager.h
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.h
@@ -94,6 +94,10 @@ typedef NS_ENUM(int, MQTTSessionManagerState) {
  */
 @property (weak, nonatomic) id<MQTTSessionManagerDelegate> delegate;
 
+/** indicates if manager requires tear down
+ */
+@property (readonly) BOOL requiresTearDown;
+
 /** subscriptions is a dictionary of NSNumber instances indicating the MQTTQoSLevel.
  *  The keys are topic filters.
  *  The SessionManager subscribes to the given subscriptions after successfull (re-)connect

--- a/MQTTClient/MQTTClient/MQTTSessionManager.m
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.m
@@ -334,6 +334,11 @@
     [self.reconnectTimer stop];
 }
 
+- (BOOL)requiresTearDown {
+    return (self.state != MQTTSessionManagerStateClosed &&
+            self.state != MQTTSessionManagerStateStarting);
+}
+
 - (void)updateState:(MQTTSessionManagerState)newState {
     self.state = newState;
 


### PR DESCRIPTION
Same PR as was closed.

Hello!
Main issue this PR is fixing is:
I was profiling my app's energy consumption and noticed that after pressing home button app state was changed to background, not suspended(as expected). And the only place where BG task was created is MQTTSessionManager.
I'm using default init, so shouldConnectInForeground is TRUE.