### PR TITLE
[FIX] connectToLast now can actually reconnect

### DIFF
--- a/MQTTClient/MQTTClient/MQTTSessionManager.m
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.m
@@ -459,7 +459,7 @@
 
 - (void)connectToLast {
     [self.reconnectTimer resetRetryInterval];
-    [self connectToInternal];
+    [self reconnect];
 }
 
 - (void)triggerDelayedReconnect {

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Or include the source from here.
 ### With Carthage
 
 [Carthage](https://github.com/Carthage/Carthage)
+```
+github "ckrey/MQTT-Client-Framework"
+```
 
 ### docs
 


### PR DESCRIPTION
Recent changes to `- (void)handleEvent:(MQTTSession *)session event:(MQTTSessionEvent)eventCode error:(NSError *)error` made it possible to leave MQTTSessionManager in MQTTSessionManagerStateClosed state, so there is no way that `connectToInternal ` will start connection as it treat only  MQTTSessionManagerStateStarting as a start condition. 

Previously after closing session state was always changed to MQTTSessionManagerStateStarting.

For me proposed solution seems to be fine as ` - (void)connectToLast ` is called only from 2 places:
- `- (void)appDidBecomeActive` of ForegroundReconnection
- `- (UInt16)sendData:(NSData *)data topic:(NSString *)topic qos:(MQTTQosLevel)qos retain:(BOOL)retainFlag`
and we should start the connection from scratch if we finished with error or just closed