### PR TITLE
Manual PUBACKs support

### DIFF
--- a/MQTTClient/MQTTClient/MQTTSession.h
+++ b/MQTTClient/MQTTClient/MQTTSession.h
@@ -604,7 +604,8 @@ typedef void (^MQTTPublishHandler)(NSError *error);
  
  */
 
-- (UInt16)subscribeToTopic:(NSString *)topic atLevel:(MQTTQosLevel)qosLevel subscribeHandler:(MQTTSubscribeHandler)subscribeHandler explicitAcks:(BOOL)explicitAcks;
+- (UInt16)subscribeToTopic:(NSString *)topic atLevel:(MQTTQosLevel)qosLevel subscribeHandler:(MQTTSubscribeHandler)subscribeHandler;
+
 
 /** subscribes to a topic at a specific QoS level
  
@@ -624,7 +625,8 @@ typedef void (^MQTTPublishHandler)(NSError *error);
  
  */
 
-- (UInt16)subscribeToTopic:(NSString *)topic atLevel:(MQTTQosLevel)qosLevel subscribeHandler:(MQTTSubscribeHandler)subscribeHandler;
+- (UInt16)subscribeToTopic:(NSString *)topic atLevel:(MQTTQosLevel)qosLevel subscribeHandler:(MQTTSubscribeHandler)subscribeHandler explicitAcks:(BOOL)explicitAcks;
+
 
 /** subscribes a number of topics
  

--- a/MQTTClient/MQTTClient/MQTTSession.h
+++ b/MQTTClient/MQTTClient/MQTTSession.h
@@ -604,6 +604,26 @@ typedef void (^MQTTPublishHandler)(NSError *error);
  
  */
 
+- (UInt16)subscribeToTopic:(NSString *)topic atLevel:(MQTTQosLevel)qosLevel subscribeHandler:(MQTTSubscribeHandler)subscribeHandler explicitAcks:(BOOL)explicitAcks;
+
+/** subscribes to a topic at a specific QoS level
+ 
+ @param topic the Topic Filter to subscribe to.
+ 
+ @param qosLevel specifies the QoS Level of the subscription.
+ qosLevel can be 0, 1, or 2.
+ @param subscribeHandler identifies a block which is executed on successfull or unsuccessfull subscription.
+ Might be nil. error is nil in the case of a successful subscription. In this case gQoss represents an
+ array of grantes Qos
+
+ @param explicitAcks If set to YES, messages will not be ACKed automatically. To acknowledge a message, call sendAckWithMessageId:
+ 
+ @return the Message Identifier of the SUBSCRIBE message.
+ 
+ @note returns immediately. To check results, register as an MQTTSessionDelegate and watch for events.
+ 
+ */
+
 - (UInt16)subscribeToTopic:(NSString *)topic atLevel:(MQTTQosLevel)qosLevel subscribeHandler:(MQTTSubscribeHandler)subscribeHandler;
 
 /** subscribes a number of topics
@@ -849,6 +869,16 @@ typedef void (^MQTTPublishHandler)(NSError *error);
  @endcode
  
  */
+
+
+/**
+ Sends an ACK message. Use this only to acknowledge messages received on a topic with the explicitAcks set to YES.
+ 
+ @param mid Message id
+ 
+ */
+- (void)sendAckForMessageId:(unsigned int)mid;
+
 - (void)closeWithDisconnectHandler:(MQTTDisconnectHandler)disconnectHandler;
 
 /** close V5


### PR DESCRIPTION
Provides the possibility of sending PUBACKs explicitly, instead of automatically or by the MQTTSessionDelegate method that returns a BOOL marking a message processed.

This feature practically only makes sense if MQTT message payloads are processed asynchronously or in batches (meaning the -(void)newMessage: method merely queues the message for later processing).