### PR TITLE
Modify ddLogLevel to MQTTLogLevel as suggested by CocoaLumberjack

### DIFF
--- a/MQTTClient/MQTTClient/MQTTLog.h
+++ b/MQTTClient/MQTTClient/MQTTLog.h
@@ -14,7 +14,7 @@
 
 #ifdef LUMBERJACK
 
-#define LOG_LEVEL_DEF ddLogLevel
+#define LOG_LEVEL_DEF MQTTLogLevel
 #import <CocoaLumberjack/CocoaLumberjack.h>
 
 #else /* LUMBERJACK */
@@ -83,11 +83,11 @@ DDLogLevelAll       = NSUIntegerMax
 
 #ifdef DEBUG
 
-#define DDLogVerbose if (ddLogLevel & DDLogFlagVerbose) NSLog
-#define DDLogDebug if (ddLogLevel & DDLogFlagDebug) NSLog
-#define DDLogWarn if (ddLogLevel & DDLogFlagWarning) NSLog
-#define DDLogInfo if (ddLogLevel & DDLogFlagInfo) NSLog
-#define DDLogError if (ddLogLevel & DDLogFlagError) NSLog
+#define DDLogVerbose if (MQTTLogLevel & DDLogFlagVerbose) NSLog
+#define DDLogDebug if (MQTTLogLevel & DDLogFlagDebug) NSLog
+#define DDLogWarn if (MQTTLogLevel & DDLogFlagWarning) NSLog
+#define DDLogInfo if (MQTTLogLevel & DDLogFlagInfo) NSLog
+#define DDLogError if (MQTTLogLevel & DDLogFlagError) NSLog
 
 #else
 
@@ -100,7 +100,7 @@ DDLogLevelAll       = NSUIntegerMax
 #endif /* DEBUG */
 #endif /* LUMBERJACK */
 
-extern DDLogLevel ddLogLevel;
+extern DDLogLevel MQTTLogLevel;
 
 /** MQTTLog lets you define the log level for MQTTClient
  *  independently of using CocoaLumberjack

--- a/MQTTClient/MQTTClient/MQTTLog.m
+++ b/MQTTClient/MQTTClient/MQTTLog.m
@@ -12,16 +12,16 @@
 
 #ifdef DEBUG
 
-DDLogLevel ddLogLevel = DDLogLevelVerbose;
+DDLogLevel MQTTLogLevel = DDLogLevelVerbose;
 
 #else
 
-DDLogLevel ddLogLevel = DDLogLevelWarning;
+DDLogLevel MQTTLogLevel = DDLogLevelWarning;
 
 #endif
 
 + (void)setLogLevel:(DDLogLevel)logLevel {
-    ddLogLevel = logLevel;
+    MQTTLogLevel = logLevel;
 }
 
 @end


### PR DESCRIPTION
There are suggestions in CocoaLumberjack.h: Define your LOG_LEVEL_DEF to a different variable/function than ddLogLevel.
```
/**
 * Welcome to CocoaLumberjack!
 *
 * The project page has a wealth of documentation if you have any questions.
 * https://github.com/CocoaLumberjack/CocoaLumberjack
 *
 * If you're new to the project you may wish to read "Getting Started" at:
 * Documentation/GettingStarted.md
 *
 * Otherwise, here is a quick refresher.
 * There are three steps to using the macros:
 *
 * Step 1:
 * Import the header in your implementation or prefix file:
 *
 * #import <CocoaLumberjack/CocoaLumberjack.h>
 *
 * Step 2:
 * Define your logging level in your implementation file:
 *
 * // Log levels: off, error, warn, info, verbose
 * static const DDLogLevel ddLogLevel = DDLogLevelVerbose;
 *
 * Step 2 [3rd party frameworks]:
 *
 * Define your LOG_LEVEL_DEF to a different variable/function than ddLogLevel:
 *
 * // #undef LOG_LEVEL_DEF // Undefine first only if needed
 * #define LOG_LEVEL_DEF myLibLogLevel
 *
 * Define your logging level in your implementation file:
 *
 * // Log levels: off, error, warn, info, verbose
 * static const DDLogLevel myLibLogLevel = DDLogLevelVerbose;
 *
 * Step 3:
 * Replace your NSLog statements with DDLog statements according to the severity of the message.
 *
 * NSLog(@"Fatal error, no dohickey found!"); -> DDLogError(@"Fatal error, no dohickey found!");
 *
 * DDLog works exactly the same as NSLog.
 * This means you can pass it multiple variables just like NSLog.
 **/
```