### PR TITLE
Added ALPN support

### DIFF
--- a/MQTTClient/MQTTClient/MQTTCFSocketTransport.h
+++ b/MQTTClient/MQTTClient/MQTTCFSocketTransport.h
@@ -42,6 +42,10 @@
 /// A Boolean value indicating whether the transport should send data over the cell network. Defaults to `YES`.
 @property (nonatomic) BOOL allowsCellularAccess;
 
+/** ALPN to use, default to not use ALPN
+ */
+@property (strong, nonatomic) NSArray *alpn;
+
 /** Require for VoIP background service
  * defaults to NO
  */

--- a/MQTTClient/MQTTClient/MQTTSSLSecurityPolicyTransport.m
+++ b/MQTTClient/MQTTClient/MQTTSSLSecurityPolicyTransport.m
@@ -65,6 +65,23 @@
                                                code:errSSLInternal
                                            userInfo:@{NSLocalizedDescriptionKey : @"Fail to init ssl output stream!"}];
         }
+        
+        if (@available(iOS 11, *)) {
+            if (self.alpn != nil && [self.alpn count] > 0) {
+                OSStatus err;
+                SSLContextRef sslContext = CFReadStreamCopyProperty(readStream, kCFStreamPropertySSLContext);
+                if ((err = SSLSetALPNProtocols(sslContext, (__bridge CFArrayRef) self.alpn))) {
+                    connectError = [NSError errorWithDomain:@"MQTT" code:err userInfo:@{
+                        NSLocalizedDescriptionKey : @"ALPN error"}];
+                }
+                
+                sslContext = CFWriteStreamCopyProperty(writeStream, kCFStreamPropertySSLContext);
+                if ((err = SSLSetALPNProtocols(sslContext, (__bridge CFArrayRef) self.alpn))) {
+                    connectError = [NSError errorWithDomain:@"MQTT" code:err userInfo:@{
+                        NSLocalizedDescriptionKey : @"ALPN error"}];
+                }
+            }
+        }
     }
     
     if (!connectError) {

--- a/MQTTClient/MQTTClient/MQTTSessionManager.h
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.h
@@ -90,6 +90,10 @@ typedef NS_ENUM(int, MQTTSessionManagerState) {
  */
 @property (readonly) UInt32 port;
 
+/** alpn to negotiate in TLS sessions
+ */
+@property (strong, nonatomic) NSArray *alpn;
+
 /** the delegate receiving incoming messages
  */
 @property (weak, nonatomic) id<MQTTSessionManagerDelegate> delegate;

--- a/MQTTClient/MQTTClient/MQTTSessionManager.m
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.m
@@ -354,6 +354,7 @@
         transport.voip = self.session.voip;
         transport.queue = self.queue;
         transport.streamSSLLevel = self.streamSSLLevel;
+        transport.alpn = self.alpn;
         self.session.transport = transport;
         [self.session connectWithConnectHandler:connectHandler];
     }


### PR DESCRIPTION
Fixes #578 

This PR added ALPN support. Notably, it is required for custom authentication support on AWS MQTT port 443.

To use ALPN, set the `alpn` attribute in MQTTSessionManager to an array of strings. I choose not to add this to the connectTo function to allow for backwards compatibility.
