### PR TITLE
Fix: Fix crash in MQTTCFSocketEncoder

### DIFF
--- a/MQTTClient.podspec
+++ b/MQTTClient.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |mqttc|
 	mqttc.name         = "MQTTClient"
-	mqttc.version      = "0.15.3"
+	mqttc.version      = "0.15.4"
 	mqttc.summary      = "iOS, macOS and tvOS native ObjectiveC MQTT Client Framework"
 	mqttc.homepage     = "https://github.com/novastone-media/MQTT-Client-Framework"
 	mqttc.license      = { :type => "EPLv1", :file => "LICENSE" }
@@ -91,7 +91,7 @@ Pod::Spec.new do |mqttc|
 
 	mqttc.subspec 'Websocket' do |ws|
 		ws.source_files = "MQTTClient/MQTTClient/MQTTWebsocketTransport/*.{h,m}"
-		ws.dependency 'SocketRocket'
+        ws.dependency 'SocketRocket', '0.5.1'
 		ws.dependency 'MQTTClient/Min'
 		ws.requires_arc = true
 		ws.libraries = "icucore"
@@ -99,7 +99,7 @@ Pod::Spec.new do |mqttc|
 
 	mqttc.subspec 'WebsocketL' do |wsl|
 		wsl.source_files = "MQTTClient/MQTTClient/MQTTWebsocketTransport/*.{h,m}"
-		wsl.dependency 'SocketRocket'
+        ws.dependency 'SocketRocket', '0.5.1'
 		wsl.dependency 'MQTTClient/MinL'
 		wsl.requires_arc = true
 		wsl.libraries = "icucore"

--- a/MQTTClient/MQTTClient/MQTTCFSocketEncoder.m
+++ b/MQTTClient/MQTTClient/MQTTCFSocketEncoder.m
@@ -45,6 +45,13 @@
 }
 
 - (void)stream:(NSStream *)sender handleEvent:(NSStreamEvent)eventCode {
+    // We contact our delegate, MQTTSession at some point in this method
+    // This call can cause MQTTSession to dealloc and thus, MQTTDecoder to dealloc
+    // So we end up with invalid object in the middle of the method
+    // To prevent this we retain self for duration of this method call
+    MQTTCFSocketEncoder *strongEncoder = self;
+    (void)strongEncoder;
+
     if (eventCode & NSStreamEventOpenCompleted) {
         DDLogVerbose(@"[MQTTCFSocketEncoder] NSStreamEventOpenCompleted");
     }


### PR DESCRIPTION
Fixed crash in MQTTCFSocketEncoder.m by holding strong `self` reference, similarly how it's done in `MQTTDecoder`
Fixed version of `SocketRocket` dependency to 0.5.1 to allow this framework to be built

Based on following issues/commits/PRs from main repo:
https://github.com/robnadin/MQTT-Client-Framework/commit/de8982dad71da98fa6de98b00535bb81c8f3f4a8
https://github.com/novastone-media/MQTT-Client-Framework/pull/598/files